### PR TITLE
Use #flat_map instead of #map{}.flatten

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -152,7 +152,7 @@ module Edge
       # Returns all descendants
       def descendants
         if children.present?
-          children + children.map(&:descendants).flatten
+          children + children.flat_map(&:descendants)
         else
           []
         end


### PR DESCRIPTION
Using flat_map seems to have measurable performance gains over map.flatten.

Bit more info here: http://gistflow.com/posts/578-use-flat_map-instead-of-map-flatten
