### PR TITLE
class_name option expects a string

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -16,7 +16,7 @@ module Edge
         self.forest_order = options[:order] || nil
 
         common_options = {
-          :class_name => self,
+          :class_name => self.name,
           :foreign_key => forest_foreign_key
         }
 

--- a/spec/forest_spec.rb
+++ b/spec/forest_spec.rb
@@ -218,10 +218,11 @@ describe "Edge::Forest" do
 
   describe "self.acts_as_forest" do
     it 'can be used twice' do
-      Location2 = Class.new(ActiveRecord::Base) do
+      class Location2 < ActiveRecord::Base
         self.table_name = 'locations'
         acts_as_forest :order => "name"
       end
+
       Location2.find_forest
     end
   end


### PR DESCRIPTION
I had an issue with another gem trying to call `constantize` on the `class_name` option of each `belongs_to` relationship in my model. If I declared the `acts_as_forest` before the other gem, it would break - trying to call `constantize` on the class. Plus, the docs always show using a string to specify the `class_name`.