### PR TITLE
Fixed premature SQL-ization that could result in PG protocol violation errors

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -96,7 +96,7 @@ module Edge
       # Only where scopes can precede this in a scope chain
       def with_descendants
         manager = recursive_manager.project(arel_table[:id])
-        scope = unscoped.where("#{table_name}.id in (#{manager.to_sql})")
+        scope = unscoped.where(arel_table[:id].in manager)
         scope.bind_values = current_scope.bind_values if current_scope
         scope
       end


### PR DESCRIPTION
Resolves issue <https://github.com/jackc/edge/issues/14>.

Calling `to_sql` and then adding subsequent scopes can result in SQL containing `WHERE FOO = $1 AND BAR = $1`, where the second `$1` should be `$2`.

See <https://github.com/rails/rails/issues/20236> for a complete explanation.