### PR TITLE
Support dependent option

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -7,7 +7,7 @@ module Edge
       # * foreign_key - column name to use for parent foreign_key (default: parent_id)
       # * order - how to order children (default: none)
       def acts_as_forest(options={})
-        options.assert_valid_keys :foreign_key, :order
+        options.assert_valid_keys :foreign_key, :order, :dependent
 
         class_attribute :forest_foreign_key
         self.forest_foreign_key = options[:foreign_key] || "parent_id"
@@ -20,12 +20,14 @@ module Edge
           :foreign_key => forest_foreign_key
         }
 
+        dependent_options = options[:dependent] ? { dependent: options[:dependent] } : {}
+
         belongs_to :parent, common_options.merge(inverse_of: :children)
 
         if forest_order
-          has_many :children, -> { order(forest_order) }, common_options.merge(inverse_of: :parent)
+          has_many :children, -> { order(forest_order) }, common_options.merge(inverse_of: :parent).merge(dependent_options)
         else
-          has_many :children, common_options.merge(inverse_of: :parent)
+          has_many :children, common_options.merge(inverse_of: :parent).merge(dependent_options)
         end
 
         scope :root, -> { where(forest_foreign_key => nil) }


### PR DESCRIPTION
I think most of the time we want to delete the children after parent was deleted.

So a `dependent` option would be very useful, so that we can do:

```
acts_as_forest order: "name", dependent: :destroy
```
