### PR TITLE
Make `optional` option available

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -7,8 +7,9 @@ module Edge
       # * dependent - passed to children has_many (default: none)
       # * foreign_key - column name to use for parent foreign_key (default: parent_id)
       # * order - how to order children (default: none)
+      # * optional - passed to belongs_to (default: none)
       def acts_as_forest(options={})
-        options.assert_valid_keys :foreign_key, :order, :dependent
+        options.assert_valid_keys :foreign_key, :order, :dependent, :optional
 
         class_attribute :forest_foreign_key
         self.forest_foreign_key = options[:foreign_key] || "parent_id"
@@ -23,7 +24,9 @@ module Edge
 
         dependent_options = options[:dependent] ? { dependent: options[:dependent] } : {}
 
-        belongs_to :parent, common_options.merge(inverse_of: :children)
+        optional_options = (ActiveRecord::VERSION::MAJOR >= 5 && options[:optional]) ? { optional: options[:optional] } : {}
+
+        belongs_to :parent, common_options.merge(inverse_of: :children).merge(optional_options)
 
         if forest_order
           has_many :children, -> { order(forest_order) }, common_options.merge(inverse_of: :parent).merge(dependent_options)

--- a/spec/forest_spec.rb
+++ b/spec/forest_spec.rb
@@ -258,4 +258,26 @@ describe "Edge::Forest" do
     end
 
   end
+
+  if ActiveRecord::VERSION::MAJOR >= 5
+    describe "optional option" do
+      before do
+        @original_value = ActiveRecord::Base.belongs_to_required_by_default
+        ActiveRecord::Base.belongs_to_required_by_default = true
+      end
+
+      after do
+        ActiveRecord::Base.belongs_to_required_by_default = @original_value
+      end
+
+      it 'parent can be nil' do
+        class Location4 < ActiveRecord::Base
+          self.table_name = "locations"
+          acts_as_forest optional: true
+        end
+
+        expect(Location4.new(name: "Iceland").valid?).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
In Rails 5.0, `belongs_to` will now trigger a validation error by default if the association is not present.  
But the root element does not have a parent. Therefore, I want to be able to pass `optional` option to avoid validation error.
