### PR TITLE
Ruby 3 support

### DIFF
--- a/lib/edge/forest.rb
+++ b/lib/edge/forest.rb
@@ -26,12 +26,12 @@ module Edge
 
         optional_options = options[:optional] ? { optional: options[:optional] } : {}
 
-        belongs_to :parent, common_options.merge(inverse_of: :children).merge(optional_options)
+        belongs_to :parent, **common_options.merge(inverse_of: :children).merge(optional_options)
 
         if forest_order
-          has_many :children, -> { order(forest_order) }, common_options.merge(inverse_of: :parent).merge(dependent_options)
+          has_many :children, -> { order(forest_order) }, **common_options.merge(inverse_of: :parent).merge(dependent_options)
         else
-          has_many :children, common_options.merge(inverse_of: :parent).merge(dependent_options)
+          has_many :children, **common_options.merge(inverse_of: :parent).merge(dependent_options)
         end
 
         scope :root, -> { where(forest_foreign_key => nil) }


### PR DESCRIPTION
This adds support for ruby 3.0

Ruby 3.0 requires to use double splat(**) operator when passing hash as kwargs https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Tests are also passing on ruby 2.3.8 which is the minimum version specified in travis.yml